### PR TITLE
fix: add missing setting xml entry to avoid System Settings crash

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -69,6 +69,10 @@
       <label>Need this to enable a refetch button in the config page that bypasses the apply button.</label>
       <default>false</default>
     </entry>
+    <entry name="currentWallpaperThumbnail" type="String">
+      <label>Small wallpaper preview</label>
+      <default></default>
+    </entry>
   </group>
 
 </kcfg>


### PR DESCRIPTION
With the following error:
QDBusMarshaller: cannot add a null QDBusVariant
dbus[193395]: Array or variant type requires that type variant be written, but end_dict_entry was written. The overall signature expected here was 'sa{sv}' and we are on byte 4 of that signature.
  D-Bus not built with -rdynamic so unable to print a backtrace